### PR TITLE
ICwAuthenticationStateProvider instead of AuthenticationStateProvider for testing

### DIFF
--- a/Proinug.Tests/Proinug.Tests.csproj
+++ b/Proinug.Tests/Proinug.Tests.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="bunit" Version="1.4.15" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Proinug.WebUI/Components/LoginForm.razor
+++ b/Proinug.WebUI/Components/LoginForm.razor
@@ -5,10 +5,10 @@
     <div class="alert alert-danger d-flex align-items-center" role="alert">
         <span class="oi oi-warning flex-shrink-0 me-3 ms-1 fs-3" role="img" aria-label="Danger:"></span>
         <div>
-            <div>
+            <div id="alert-error-message">
                 @_errorMessage
             </div>
-            <div>
+            <div id="alert-error-code">
                 Error: @_errorCode
             </div>
         </div>

--- a/Proinug.WebUI/Components/LoginForm.razor.cs
+++ b/Proinug.WebUI/Components/LoginForm.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using HigLabo.Core;
+using Proinug.WebUI.Interfaces;
 using Proinug.WebUI.Models;
 using Proinug.WebUI.Services;
 using Proinug.WebUI.ViewModels;
@@ -10,7 +11,7 @@ namespace Proinug.WebUI.Components;
 public partial class LoginForm
 {
     [Inject]
-    public AuthenticationStateProvider? AuthenticationStateProvider { get; set; }
+    public ICwAuthenticationStateProvider? AuthenticationStateProvider { get; set; }
     [Inject]
     public NavigationManager? NavigationManager { get; set; }
     
@@ -24,10 +25,9 @@ public partial class LoginForm
         _errorCode = 0;
         
         if (AuthenticationStateProvider == null) return;
-        var asp = (CwAuthenticationStateProvider) AuthenticationStateProvider;
-
+        
         _busy = true;
-        _errorCode = await asp.LoginAsync(_credentials.Map(new Credentials()));
+        _errorCode = await AuthenticationStateProvider.LoginAsync(_credentials.Map(new Credentials()));
 
         if (_errorCode == 401)
         {

--- a/Proinug.WebUI/Interfaces/ICwAuthenticationStateProvider.cs
+++ b/Proinug.WebUI/Interfaces/ICwAuthenticationStateProvider.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Components.Authorization;
+using Proinug.WebUI.Dto;
+using Proinug.WebUI.Models;
+
+namespace Proinug.WebUI.Interfaces;
+
+public interface ICwAuthenticationStateProvider
+{
+    TokenDto? TokenDto { get; }
+
+    /// <summary>
+    /// Returns authentication state
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    Task<AuthenticationState> GetAuthenticationStateAsync();
+
+    /// <summary>
+    /// Login async
+    /// </summary>
+    /// <param name="credentials"></param>
+    /// <returns></returns>
+    Task<int> LoginAsync(Credentials credentials);
+
+    /// <summary>
+    /// Logout async
+    /// </summary>
+    Task LogoutAsync();
+
+    event AuthenticationStateChangedHandler? AuthenticationStateChanged;
+}

--- a/Proinug.WebUI/Program.cs
+++ b/Proinug.WebUI/Program.cs
@@ -15,8 +15,7 @@ builder.Services.AddAuthService(builder.Configuration)
     .AddScoped<ProtectedLocalStorage>()
     .AddScoped<ICwAuthenticationStateProvider, CwAuthenticationStateProvider>()
     .AddScoped<AuthenticationStateProvider>(c => 
-        (AuthenticationStateProvider?) c.GetService<ICwAuthenticationStateProvider>() 
-        ?? throw new InvalidOperationException("Can't get a service for ICwAuthenticationStateProvider"))
+        (AuthenticationStateProvider?) c.GetService<ICwAuthenticationStateProvider>()!)
     .AddSingleton<ISystemClock, RealSystemClock>();
 
 var app = builder.Build();

--- a/Proinug.WebUI/Program.cs
+++ b/Proinug.WebUI/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.AspNetCore.Components.Web;
 using Proinug.WebUI.Extensions;
+using Proinug.WebUI.Interfaces;
 using Proinug.WebUI.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,7 +13,10 @@ builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddAuthService(builder.Configuration)
     .AddScoped<ProtectedLocalStorage>()
-    .AddScoped<AuthenticationStateProvider, CwAuthenticationStateProvider>()
+    .AddScoped<ICwAuthenticationStateProvider, CwAuthenticationStateProvider>()
+    .AddScoped<AuthenticationStateProvider>(c => 
+        (AuthenticationStateProvider?) c.GetService<ICwAuthenticationStateProvider>() 
+        ?? throw new InvalidOperationException("Can't get a service for ICwAuthenticationStateProvider"))
     .AddSingleton<ISystemClock, RealSystemClock>();
 
 var app = builder.Build();

--- a/Proinug.WebUI/Services/CwAuthenticationStateProvider.cs
+++ b/Proinug.WebUI/Services/CwAuthenticationStateProvider.cs
@@ -12,7 +12,7 @@ namespace Proinug.WebUI.Services;
 /// <summary>
 /// Custom authentication state provider
 /// </summary>
-public class CwAuthenticationStateProvider : AuthenticationStateProvider
+public class CwAuthenticationStateProvider : AuthenticationStateProvider, ICwAuthenticationStateProvider
 {
     private const string USER_SESSION_OBJECT_KEY = "user_session_obj";
     
@@ -100,7 +100,7 @@ public class CwAuthenticationStateProvider : AuthenticationStateProvider
         }
         NotifyAuthenticationStateChanged(Task.FromResult(GenerateEmptyAuthenticationState()));
     }
-    
+
     /// <summary>
     /// Token is valid
     /// </summary>


### PR DESCRIPTION
Can't mock CwAuthenticationStateProvider's methods. So the way is to make them either virtual or extract an Interface. I like interfaces more, so choosed to extract ICwAuthenticationStateProvider.
It needed some changes in the project.
Also wrote tests for LoginForm after that using Moq.